### PR TITLE
Move loris.config provider from annex to git

### DIFF
--- a/.datalad/providers/loris.cfg
+++ b/.datalad/providers/loris.cfg
@@ -1,1 +1,9 @@
-../../.git/annex/objects/P5/1v/MD5E-s297--3610b748aa323c3d64106cb69b017446.cfg/MD5E-s297--3610b748aa323c3d64106cb69b017446.cfg
+[provider:loris-phantom-dev]
+url_re = https:\/\/phantom-dev.loris.ca\/.*
+credential = loris-phantom-dev
+authentication_type = loris-token
+loris-token_failure_re = "User not authenticated"}$
+
+[credential:loris-phantom-dev]
+url = https://phantom-dev.loris.ca/api/v0.0.3-dev/login
+type = loris-token


### PR DESCRIPTION
Taking loris.config provider rout of git-annex to make it visible when cloning the dataset