### PR TITLE
Adding PI identifier to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -24,7 +24,15 @@
             "@type": "Organization",
             "name": "McGill Center for Integrative Neuroscience",
             "abbreviation": "MCIN"
-        }
+        },
+	{
+		"name": "Samir Das",
+		"roles": [
+			{
+				"value": "Principal Investigator"
+			}
+		]
+	}
     ],
     "types": [
         { 

--- a/DATS.json
+++ b/DATS.json
@@ -26,7 +26,7 @@
             "abbreviation": "MCIN"
         },
 	{
-		"name": "Samir Das",
+		"name": "Alan C. Evans",
 		"roles": [
 			{
 				"value": "Principal Investigator"


### PR DESCRIPTION
This PR adds an entry for Samir Das under `creators->names` in the DATS.json file and assigns the value "Principal Investigator" to him under `roles->value`.