### PR TITLE
adding "force_ask" to .datalad/config

### DIFF
--- a/.datalad/config
+++ b/.datalad/config
@@ -2,3 +2,5 @@
 	id = 8de99b0e-5f94-11e9-9e05-52545e9add8e
 [datalad "metadata"]
 	nativetype = minc
+[credentials]
+    force-ask = true


### PR DESCRIPTION
This PR adds a command to the datalad configuration file to require users to re-login with user and password each time they download this dataset, avoiding a problem where login credentials were sometimes not requested and downloads would hang indefinitely.
